### PR TITLE
improve(autolist): smart continuation for empty list items

### DIFF
--- a/lua/markdown-toggle/init.lua
+++ b/lua/markdown-toggle/init.lua
@@ -695,14 +695,24 @@ end
 ---@param cin string character input
 ---@param is_blank boolean whether the line is blank
 local clear_and_insert = function(cin, is_blank)
-  vim.api.nvim_set_current_line("") -- Clear current line
+  local cursor_line_num = vim.api.nvim_win_get_cursor(0)[1]
 
-  if cin == "o" or cin == "O" then
-    vim.api.nvim_feedkeys(cin, "n", false)
+  if cin == "o" then
+    -- Clear current line and create new line below
+    vim.api.nvim_set_current_line("")
+    vim.api.nvim_win_set_cursor(0, { cursor_line_num, 0 })
+    vim.cmd("startinsert")
+  elseif cin == "O" then
+    -- Clear current line and create new line above
+    vim.api.nvim_set_current_line("")
+    vim.api.nvim_win_set_cursor(0, { cursor_line_num, 0 })
+    vim.cmd("startinsert")
   elseif cin == util.get_eol() then
+    vim.api.nvim_set_current_line("")
     if is_blank then
       vim.api.nvim_feedkeys(cin, "n", false)
     else
+      vim.api.nvim_win_set_cursor(0, { cursor_line_num, 0 })
       vim.cmd("startinsert")
     end
   end


### PR DESCRIPTION
I have implemented the feature I proposed in #34. Now, when a ordered list, unordered list, or checkbox is empty and the user <CR> or types o, the empty item gets deleted.
I have slightly changed the regex of checkboxes, lists and olists, in order to capture the text and the trailing spaces after the text.
For instance, if I have
- [ ] Hello  => it matches, text is Hello and trailing is ""
- [ ]           => it matches, text is "" and trailing is "        ".
So the condition for each list type is to have text = "", since it means that, no matter the amount of spaces after the text capture group, the list item is empty

The only issues that I've encountered are:
1. When using O and o, the line gets correctly emptied, but, I don't know why, the mode remains normal and not insert. That could be related to the empty_current_line() function I've added, which takes the current line and empties it (without deleting it, so that the cursor doesn't go the previous line)
2. I couldn't add the feature to quotes. I didn't know how. I tried doing the same thing I did with the other list types, so I took the sep_quotes.body, matched it with regex "^(.-)(%s*)$" in order to capture the text and the whitespaces. The problem is that, in the  
`elseif sep_quote.mark then` branch, if I do the match and check against the captured quote_text, <CR> doesn't work with any line 


This is a preview
![2025-11-16 16-39-19](https://github.com/user-attachments/assets/e94e2725-1dbf-47b8-8afc-c0358358c8c0)
